### PR TITLE
fix incorrect error formatting in semaphore acquisition log

### DIFF
--- a/pkg/actions/nodegroup/drain.go
+++ b/pkg/actions/nodegroup/drain.go
@@ -58,6 +58,6 @@ func (d *Drainer) Drain(ctx context.Context, input *DrainInput) error {
 
 func waitForAllRoutinesToFinish(ctx context.Context, sem *semaphore.Weighted, size int64) {
 	if err := sem.Acquire(ctx, size); err != nil {
-		logger.Critical("failed to acquire semaphore while waiting for all routines to finish: %w", err)
+		logger.Critical("failed to acquire semaphore while waiting for all routines to finish: %v", err)
 	}
 }


### PR DESCRIPTION
Replaced `%w` with `%v` in the logging statement to properly format the error message. `%w` should only be used in `fmt.Errorf` for wrapping errors, not in logging, which caused incorrect formatting as shown below.

```
2024-06-13 20:46:37 [i]  starting parallel draining, max in-flight of 1
2024-06-13 20:46:37 [x]  failed to acquire semaphore while waiting for all routines to finish: %!w(*errors.errorString=&{context canceled})
2024-06-13 20:46:38 [i]  deleted 0 Fargate profile(s)
```